### PR TITLE
fix: retornar codigo 404 quando houver um entitynotfoundexception

### DIFF
--- a/src/main/java/dev/felipequeiroz/simplepms/infra/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dev/felipequeiroz/simplepms/infra/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package dev.felipequeiroz.simplepms.infra.exception;
 
 import dev.felipequeiroz.simplepms.exception.BusinessValidationException;
 import jakarta.persistence.ElementCollection;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -21,6 +22,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ResponseStatusException.class)
     public ResponseEntity tratarResponseStatusException(ResponseStatusException ex) {
         return ResponseEntity.status(ex.getStatusCode()).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity tratarEntityNotFoundException(EntityNotFoundException ex) {
+        return ResponseEntity.notFound().build();
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)


### PR DESCRIPTION
Corrigido o comportamento da aplicação para retornar o erro 404 quando houver uma entidade não localizada no banco de dados.